### PR TITLE
Fix/progress bar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.gitversion.outputs.SemVer }}
+          tag_name: v${{ steps.gitversion.outputs.SemVer }}
           release_name: Release ${{ steps.gitversion.outputs.SemVer }}
           draft: false
           prerelease: true

--- a/lib/ota_manager/src/ota_manager.cpp
+++ b/lib/ota_manager/src/ota_manager.cpp
@@ -26,7 +26,7 @@ bool OtaManager::updateAvailable()
     SPIFFSManager spiffsManager;
     const char *jsonPath = "/firmware.json";
 
-    if (!downloadFile(m_firmwareInfoUrl, jsonPath))
+    if (!downloadFile(m_firmwareInfoUrl, jsonPath, false))
     {
         Serial.println("Failed to download firmware info");
         return false;
@@ -123,7 +123,7 @@ String OtaManager::getCurrentVersion()
     return m_currentVersion;
 }
 
-bool OtaManager::downloadFile(const String &url, const String &path)
+bool OtaManager::downloadFile(const String &url, const String &path, bool displayProgress)
 {
     HTTPClient http;
     int httpCode = http.GET();
@@ -177,7 +177,9 @@ bool OtaManager::downloadFile(const String &url, const String &path)
                 if (totalLength > 0)
                 {
                     Serial.printf("Downloaded %d of %d bytes (%.2f%%)\r", downloadedLength, totalLength, (downloadedLength * 100.0) / totalLength);
-                    m_display.fillColorPercentage((downloadedLength * 100) / totalLength, Display::Color::Orange, Display::Line::Line2, 1);
+                    // Fill the progress bar on the display only if the file is a firmware binary
+                    if (displayProgress)
+                        m_display.fillColorPercentage((downloadedLength * 100) / totalLength, Display::Color::Orange, Display::Line::Line2, 1);
                 }
                 else
                 {

--- a/lib/ota_manager/src/ota_manager.h
+++ b/lib/ota_manager/src/ota_manager.h
@@ -15,7 +15,7 @@ public:
     String getCurrentVersion();
 
 private:
-    bool downloadFile(const String &url, const String &path);
+    bool downloadFile(const String &url, const String &path, bool displayProgress = true);
     bool applyFirmware(const String &path);
     bool verifyChecksum(const String &path, const String &md5);
     String calculateMD5(const String &path);

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -41,6 +41,7 @@ void Application::init(uint8_t displayType)
     {
         m_display.printText("Connect to WiFi", Display::Line::Line1, Display::Color::Green);
         m_display.printText(m_wifiManager.getIpAddress(), Display::Line::Line2, Display::Color::Green);
+        m_display.printText("Checking for updates", Display::Line::Line3);
 
         if (!Version::localBuild())
         {
@@ -61,11 +62,12 @@ void Application::init(uint8_t displayType)
             }
         }
 
-        m_display.printText("Update departures", Display::Line::Line3, Display::Color::Orange);
+        m_display.printText("Checking for updates", Display::Line::Line3, Display::Color::Green);
+        m_display.printText("Update departures", Display::Line::Line4, Display::Color::Orange);
 
         if (getLatestAnnouncements())
         {
-            m_display.printText("Update departures", Display::Line::Line3, Display::Color::Green);
+            m_display.printText("Update departures", Display::Line::Line4, Display::Color::Green);
             delay(1000);
             updateDisplayInformation();
         }


### PR DESCRIPTION
This pull request includes improvements to the OTA (Over-the-Air) update functionality and minor updates to the release workflow and display messages. The most important changes include adding a parameter to control the display of download progress, updating display messages during initialization, and modifying the release tag format.

### OTA Update Improvements:

* [`lib/ota_manager/src/ota_manager.cpp`](diffhunk://#diff-9ce684860bfe8a2ed00805aa507da684eb70f9539420ac819c266eef85ece5d1L29-R29): Added a `displayProgress` parameter to the `downloadFile` function to control whether the download progress is shown on the display. [[1]](diffhunk://#diff-9ce684860bfe8a2ed00805aa507da684eb70f9539420ac819c266eef85ece5d1L29-R29) [[2]](diffhunk://#diff-9ce684860bfe8a2ed00805aa507da684eb70f9539420ac819c266eef85ece5d1L126-R126) [[3]](diffhunk://#diff-9ce684860bfe8a2ed00805aa507da684eb70f9539420ac819c266eef85ece5d1R180-R181)
* [`lib/ota_manager/src/ota_manager.h`](diffhunk://#diff-8ea4c76057277c4acb558e12cbf0b9ac3ddfe21a29e6ca3a845b3fa5d44418e0L18-R18): Updated the `downloadFile` function signature to include the `displayProgress` parameter with a default value of `true`.

### Display Message Updates:

* [`src/application.cpp`](diffhunk://#diff-1ac21b1b653c1f5652e24f3c5dcf82642d12ebd4dcb45e55038e827c95808d3aR44): Added and modified display messages during the initialization process to provide clearer information to the user. [[1]](diffhunk://#diff-1ac21b1b653c1f5652e24f3c5dcf82642d12ebd4dcb45e55038e827c95808d3aR44) [[2]](diffhunk://#diff-1ac21b1b653c1f5652e24f3c5dcf82642d12ebd4dcb45e55038e827c95808d3aL64-R70)

### Release Workflow Update:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L114-R114): Updated the `tag_name` format in the release workflow to include a 'v' prefix.