### PR TITLE
Fade in text during startup

### DIFF
--- a/lib/display/src/display.cpp
+++ b/lib/display/src/display.cpp
@@ -189,6 +189,29 @@ void Display::printTextRightAligned(String text, int16_t line, Color color)
     printTextRightAligned(text, x, y, color);
 }
 
+void Display::fadeInText(String text, int16_t x, int16_t y, Color color, uint16_t delayTime)
+{
+    for (uint8_t brightness = 0; brightness <= m_maxBrightness; brightness += 5)
+    {
+        setBrightness(brightness);
+        printText(text, x, y, color);
+        delay(delayTime);
+    }
+    setBrightness(m_maxBrightness); // Ensure max brightness at the end
+}
+
+void Display::fadeInTextCentered(String text, Color color, uint16_t delayTime)
+{
+    clearScreen();
+    for (uint8_t brightness = 0; brightness <= m_maxBrightness; brightness += 5)
+    {
+        setBrightness(brightness);
+        printTextCentered(text, color, false);
+        delay(delayTime);
+    }
+    setBrightness(m_maxBrightness); // Ensure max brightness at the end
+}
+
 void Display::printTextRightAligned(String text, int16_t x, int16_t y, Color color)
 {
     sanitizeText(text);
@@ -234,7 +257,7 @@ uint8_t Display::getFontHeight()
     return fontSizeInPixels(m_currentFont);
 }
 
-void Display::printTextCentered(String text, Color color)
+void Display::printTextCentered(String text, Color color, bool clearScreen)
 {
     sanitizeText(text);
     dma_display->setTextSize(1);
@@ -247,7 +270,8 @@ void Display::printTextCentered(String text, Color color)
 
     int xPosition = dma_display->width() / 2 - w / 2 + 1;
     dma_display->setCursor(xPosition, (m_matrixHeight / 2) + (fontSizeInPixels(m_currentFont) / 4));
-    dma_display->clearScreen();
+    if (clearScreen)
+        dma_display->clearScreen();
     dma_display->print(text);
 }
 

--- a/lib/display/src/display.h
+++ b/lib/display/src/display.h
@@ -54,7 +54,6 @@ public:
     void printText(String text, Line line, Color color = Color::Orange, bool clearScreen = false, uint8_t paddingTop = 0, uint8_t paddingLeft = 0);
     void printTextRightAligned(String text, int16_t line, Color color = Color::Orange);
     void printTextRightAligned(String text, int16_t x, int16_t y, Color color = Color::Orange);
-    void printTextCentered(String text, Color color = Color::Orange);
     void printTextCenteredHorizontal(String text, Line line, Color color = Color::Orange);
     void printTextCenteredHorizontal(String text, int16_t y, Color color = Color::Orange);
     void printTextCentered(String text, Color color = Color::Orange, bool clearScreen = true);

--- a/lib/display/src/display.h
+++ b/lib/display/src/display.h
@@ -57,6 +57,9 @@ public:
     void printTextCentered(String text, Color color = Color::Orange);
     void printTextCenteredHorizontal(String text, Line line, Color color = Color::Orange);
     void printTextCenteredHorizontal(String text, int16_t y, Color color = Color::Orange);
+    void printTextCentered(String text, Color color = Color::Orange, bool clearScreen = true);
+    void fadeInTextCentered(String text, Color color, uint16_t delayTime = 50);
+    void fadeInText(String text, int16_t x, int16_t y, Color color = Color::Orange, uint16_t delayTime = 50);
     uint8_t getFontHeight();
     void clearScreen();
     void setFont(Font font);

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -222,14 +222,14 @@ void Application::run()
 void Application::showSplashScreen()
 {
     m_display.clearScreen();
-    m_display.printTextCentered("Avgång by MakerMelin", Display::Color::Green);
-    delay(2000);
-    m_display.printTextCentered(Version::semver(), Display::Color::Green);
-    delay(2000);
+    m_display.fadeInTextCentered("Avgång by MakerMelin", Display::Color::Green);
+    delay(1000);
+    m_display.fadeInTextCentered(Version::semver(), Display::Color::Green);
+    delay(1000);
     if (Version::localBuild())
     {
-        m_display.printTextCentered("Local build", Display::Color::Blue);
-        delay(1000);
+        m_display.fadeInTextCentered("Local build", Display::Color::Blue);
+        delay(500);
     }
     m_display.clearScreen();
 }

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -43,7 +43,7 @@ void Application::init(uint8_t displayType)
         m_display.printText(m_wifiManager.getIpAddress(), Display::Line::Line2, Display::Color::Green);
         m_display.printText("Checking for updates", Display::Line::Line3);
 
-        if (true)
+        if (!Version::localBuild())
         {
             if (m_otaManager.updateAvailable())
             {


### PR DESCRIPTION
As extra flair, fade in the startup information instead of showing it directly.